### PR TITLE
Iobox support

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -151,6 +151,7 @@ CPPSRC = $(ALLCPPSRC) \
           can.cpp \
           can_helper.cpp \
           can_aemnet.cpp \
+          can_iobox.cpp \
           fault.cpp \
           lambda_conversion.cpp \
           pwm.cpp \

--- a/firmware/auxout.cpp
+++ b/firmware/auxout.cpp
@@ -78,7 +78,7 @@ static const int8_t auxOutPwmChN[AFR_CHANNELS] = {
 #endif
 };
 
-void SetAuxDac(int channel, float voltage)
+void SetAuxDac(size_t channel, float voltage)
 {
     voltage = voltage / AUXOUT_GAIN;
     auto duty = voltage / VCC_VOLTS;
@@ -110,7 +110,7 @@ static const uint8_t auxOutDacCh[] = {
 #endif
 };
 
-void SetAuxDac(int channel, float voltage)
+void SetAuxDac(size_t channel, float voltage)
 {
     voltage = voltage / AUXOUT_GAIN;
 

--- a/firmware/auxout.cpp
+++ b/firmware/auxout.cpp
@@ -166,6 +166,9 @@ void AuxOutThread(void*)
     {
         for (int ch = 0; ch < AFR_CHANNELS; ch++)
         {
+            if (cfg->auxOutputSource[ch] == AuxOutputMode::MsIoBox)
+                continue;
+
             float input = AuxGetInputSignal(cfg->auxOutputSource[ch]);
             float voltage = interpolate2d(input, cfg->auxOutBins[ch], cfg->auxOutValues[ch]);
 

--- a/firmware/auxout.cpp
+++ b/firmware/auxout.cpp
@@ -203,4 +203,9 @@ void InitAuxDac()
 {
 }
 
+
+void SetAuxDac(size_t, float)
+{
+}
+
 #endif

--- a/firmware/auxout.cpp
+++ b/firmware/auxout.cpp
@@ -86,7 +86,7 @@ void SetAuxDac(size_t channel, float voltage)
 
     auxDac.SetDuty(auxOutPwmCh[channel], duty);
     // Ripple cancelation channel
-    if (auxOutPwmChN[channel >= 0]) {
+    if (auxOutPwmChN[channel] >= 0) {
         auxDac.SetDuty(auxOutPwmChN[channel], duty);
     }
 }

--- a/firmware/auxout.cpp
+++ b/firmware/auxout.cpp
@@ -80,6 +80,10 @@ static const int8_t auxOutPwmChN[AFR_CHANNELS] = {
 
 void SetAuxDac(size_t channel, float voltage)
 {
+    if (channel >= AFR_CHANNELS) {
+        return;
+    }
+
     voltage = voltage / AUXOUT_GAIN;
     auto duty = voltage / VCC_VOLTS;
     duty = clampF(0, duty, 1);
@@ -112,6 +116,10 @@ static const uint8_t auxOutDacCh[] = {
 
 void SetAuxDac(size_t channel, float voltage)
 {
+    if (channel >= AFR_CHANNELS) {
+        return;
+    }
+
     voltage = voltage / AUXOUT_GAIN;
 
     auxDac.SetVoltage(auxOutDacCh[channel], voltage);

--- a/firmware/auxout.h
+++ b/firmware/auxout.h
@@ -3,4 +3,4 @@
 #include <cstdint>
 
 void InitAuxDac();
-void SetAuxDac(int channel, float voltage);
+void SetAuxDac(size_t channel, float voltage);

--- a/firmware/boards/f0_module/port.cpp
+++ b/firmware/boards/f0_module/port.cpp
@@ -147,7 +147,7 @@ void SetConfiguration()
     );
 }
 
-void ResetConfiguration();
+void ResetConfiguration(uint16_t option)
 {
     // NOP
 }

--- a/firmware/boards/f0_module/port.cpp
+++ b/firmware/boards/f0_module/port.cpp
@@ -147,6 +147,11 @@ void SetConfiguration()
     );
 }
 
+void ResetConfiguration();
+{
+    // NOP
+}
+
 SensorType GetSensorType()
 {
     return SensorType::LSU49;

--- a/firmware/boards/f1_common/f1_port.cpp
+++ b/firmware/boards/f1_common/f1_port.cpp
@@ -90,6 +90,12 @@ void Configuration::LoadDefaults()
         egt[i].AemNetIdOffset = i;
     }
 
+    iobox.idx = 0;
+    iobox.enable_rx = 0;
+    iobox.enable_tx = 0;
+    iobox.IDE = CAN_IDE_STD;
+    iobox.SID = 0x200;
+
     /* Finaly */
     Tag = ExpectedTag;
 }
@@ -125,6 +131,11 @@ Configuration* GetConfiguration()
 void SetConfiguration()
 {
     SaveConfiguration();
+}
+
+void ResetConfiguration()
+{
+    cfg.LoadDefaults();
 }
 
 /* TS stuff */

--- a/firmware/boards/f1_dual/wideband_board_config.h
+++ b/firmware/boards/f1_dual/wideband_board_config.h
@@ -1,7 +1,7 @@
 #pragma once
 
 // TS settings
-#define TS_SIGNATURE "rusEFI 2024.02.11.wideband_dual"
+#define TS_SIGNATURE "rusEFI 2025.02.04.wideband_dual"
 
 // This board implements two channels
 #define AFR_CHANNELS 2

--- a/firmware/boards/f1_dual_rev1/wideband_board_config.h
+++ b/firmware/boards/f1_dual_rev1/wideband_board_config.h
@@ -1,7 +1,7 @@
 #pragma once
 
 // TS settings
-#define TS_SIGNATURE "rusEFI 2024.02.11.wideband_dual"
+#define TS_SIGNATURE "rusEFI 2025.02.04.wideband_dual"
 
 // This board implements two channels
 #define AFR_CHANNELS 2

--- a/firmware/boards/f1_rev2/wideband_board_config.h
+++ b/firmware/boards/f1_rev2/wideband_board_config.h
@@ -1,7 +1,7 @@
 #pragma once
 
 // TS settings
-#define TS_SIGNATURE "rusEFI 2023.05.10.wideband_f1"
+#define TS_SIGNATURE "rusEFI 2025.02.04.wideband_f1"
 
 // Fundamental board constants
 #define VCC_VOLTS (3.3f)

--- a/firmware/boards/f1_rev3/wideband_board_config.h
+++ b/firmware/boards/f1_rev3/wideband_board_config.h
@@ -1,7 +1,7 @@
 #pragma once
 
 // TS settings
-#define TS_SIGNATURE "rusEFI 2023.05.10.wideband_f1"
+#define TS_SIGNATURE "rusEFI 2025.02.04.wideband_f1"
 
 // Fundamental board constants
 #define VCC_VOLTS (3.3f)

--- a/firmware/boards/port.h
+++ b/firmware/boards/port.h
@@ -45,6 +45,7 @@ enum class AuxOutputMode : uint8_t {
     Lambda1 = 3,
     Egt0 = 4,
     Egt1 = 5,
+    MsIoBox = 6,
 };
 
 class Configuration {

--- a/firmware/boards/port.h
+++ b/firmware/boards/port.h
@@ -94,6 +94,27 @@ public:
                 uint8_t AemNetIdOffset;
                 uint8_t pad[5];
             } egt[2];
+
+            // MS IO Box protocol settings
+            struct {
+                // MS IO Box index: 0, 1 or 2, else custom SID/EID is used.
+                uint8_t idx;
+                uint8_t enable_rx:1;
+                uint8_t enable_tx:1;
+                // Identifier type: CAN_IDE_STD or CAN_IDE_EXT
+                uint8_t IDE:1;
+                uint8_t pad[3];
+                union {
+                    struct {
+                        // CAN_IDE_STD
+                        uint32_t SID:11;
+                    };
+                    struct {
+                        // Extended identifier
+                        uint32_t EID:29;
+                    };
+                };
+            } iobox __attribute__((packed));
         } __attribute__((packed));
 
         // pad to 256 bytes including tag
@@ -101,9 +122,12 @@ public:
     };
 };
 
+static_assert(sizeof(Configuration) == 256);
+
 int InitConfiguration();
 Configuration* GetConfiguration();
 void SetConfiguration();
+void ResetConfiguration();
 
 /* TS stuff */
 uint8_t *GetConfigurationPtr();

--- a/firmware/boards/port.h
+++ b/firmware/boards/port.h
@@ -25,6 +25,7 @@ struct AnalogResult
     #ifdef BOARD_HAS_VOLTAGE_SENSE
     float SupplyVoltage;
     #endif
+    /* TODO: add AUX analog inputs */
 };
 
 // Enable ADCs, configure pins, etc

--- a/firmware/boards/port.h
+++ b/firmware/boards/port.h
@@ -61,6 +61,7 @@ public:
         return this->Tag == ExpectedTag;
     }
     void LoadDefaults();
+    void LoadDefaults(uint16_t option);
 
     // Actual configuration data
     union {
@@ -127,7 +128,7 @@ static_assert(sizeof(Configuration) == 256);
 int InitConfiguration();
 Configuration* GetConfiguration();
 void SetConfiguration();
-void ResetConfiguration();
+void ResetConfiguration(uint16_t option);
 
 /* TS stuff */
 uint8_t *GetConfigurationPtr();

--- a/firmware/can.cpp
+++ b/firmware/can.cpp
@@ -5,6 +5,7 @@
 #include "fault.h"
 #include "can_helper.h"
 #include "can_aemnet.h"
+#include "can_iobox.h"
 #include "heater_control.h"
 #include "lambda_conversion.h"
 #include "sampling.h"
@@ -80,6 +81,11 @@ void CanRxThread(void*)
         if (msg != MSG_OK)
         {
             continue;
+        }
+
+        if (frame.IDE == CAN_IDE_STD)
+        {
+            CanIoBoxRx(&frame);
         }
 
         // Ignore std frames, only listen to ext

--- a/firmware/can_aemnet.cpp
+++ b/firmware/can_aemnet.cpp
@@ -12,6 +12,8 @@
 #include "pump_dac.h"
 #include "max3185x.h"
 
+#include "byteswap.h"
+
 // AEMNet protocol
 
 #define AEMNET_UEGO_TX_PERIOD_MS    10

--- a/firmware/can_aemnet.h
+++ b/firmware/can_aemnet.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include "byteswap.h"
 
 void SendAemNetUEGOFormat(uint8_t ch);
 void SendAemNetEGTFormat(uint8_t ch);

--- a/firmware/can_iobox.cpp
+++ b/firmware/can_iobox.cpp
@@ -1,0 +1,210 @@
+#include "can.h"
+#include "hal.h"
+
+#include "can_helper.h"
+#include "can_iobox.h"
+
+#include "sampling.h"
+#include "byteswap.h"
+
+#define CAN_IOBOX_BASE0         0x200
+#define CAN_IOBOX_BASE1         0x220
+#define CAN_IOBOX_BASE2         0x240
+
+/* Packets from MS3 to device */
+#define CAN_IOBOX_PING          0x00
+#define CAN_IOBOX_CONFIG        0x01
+#define CAN_IOBOX_SET_PWM(n)    (0x02 + ((n) & 0x03))
+#define CAN_IOBOX_LAST_IN       0x05
+
+/* Packets from device to MS3 */
+#define CAN_IOBOX_WHOAMI        0x08
+#define CAN_IOBOX_ADC14         0x09
+#define CAN_IOBOX_ADC57         0x0A
+
+struct pwm_settings {
+    beuint16_t on;
+    beuint16_t off;
+} __attribute__ ((packed));
+
+/* Base + 0x00 */
+/* "Are you there?" packet with zero payload */
+
+/* Base + 0x01 */
+struct iobox_cfg {
+    uint8_t pwm_mask;   // 0 - On/Off, 1 - PWM
+    uint8_t pad0;
+    uint8_t tachin_mask;
+    uint8_t pad1;
+    uint8_t adc_broadcast_interval;     // mS
+    uint8_t tach_broadcast_interval;    // mS
+    uint8_t pad2[2];
+} __attribute__((packed));
+
+/* Base + 0x02, 0x03, 0x04 */
+struct iobox_pwm {
+    pwm_settings ch[2];
+} __attribute__ ((packed));
+
+static_assert(sizeof(iobox_pwm) == 8);
+
+/* Base + 0x05 */
+struct iobox_pwm_last {
+    pwm_settings ch[1];
+    uint8_t out_state;
+} __attribute__ ((packed));
+
+static_assert(sizeof(iobox_pwm_last) == 5);
+
+/* Base + 0x08 */
+struct iobox_whoami {
+    uint8_t version;
+    uint8_t pad[3];
+    beuint16_t pwm_period;      // PWM clock periods in 0.01 uS
+    beuint16_t tachin_period;   // Tach-in clock periods in 0.01 uS
+} __attribute__((packed));
+
+static_assert(sizeof(iobox_whoami) == 8);
+
+/* Base + 0x09 */
+struct iobox_adc14 {
+    beuint16_t adc[4];
+} __attribute__((packed));
+
+static_assert(sizeof(iobox_adc14) == 8);
+
+/* Base + 0x0A */
+struct iobox_adc57 {
+    uint8_t inputs;
+    uint8_t pad;
+    beuint16_t adc[3];
+} __attribute__((packed));
+
+static_assert(sizeof(iobox_adc57) == 8);
+
+// TODO: move to configuration
+static const uint32_t iobox_index = 0;
+
+static bool configured = false;
+
+static uint8_t pwm_mask = 0x00;
+static uint8_t tachin_mask = 0x00;
+static uint8_t adc_broadcast_interval = 20;
+static uint8_t tach_broadcast_interval = 20;
+
+/*
+ * TODO: validate
+ * Scale value to 0 .. 1023
+ * MegaSquirt IOBox has 0..5V ADC input range
+ */
+static uint16_t CanIoBoxGetAdc(size_t index)
+{
+    /* Total 7 ADC inputs, mapping:
+     * 1 - AUX left
+     * 2 - AUX right
+     * 3 - AUX out left voltage
+     * 4 - AUX out right voltage
+     * 5 - WBO supply voltage
+     * 6 - Left sensor heater supply
+     * 7 - Right sensor heater supply */
+    switch (index) {
+    case 0 ... 4:
+        return 0;
+    break;
+    case 5:
+        /* TODO: */
+        return 0;
+    case 6:
+    case 7:
+        {
+            const auto& sampler = GetSampler(index - 6);
+
+            /* TODO: clamp */
+            return sampler.GetInternalHeaterVoltage() / 25.5 * 1024;
+        }
+    break;
+
+    default:
+    return 0.0;
+    }
+}
+
+int CanIoBoxRx(const CANRxFrame *fr)
+{
+    const uint32_t base = CAN_IOBOX_BASE0 + iobox_index * 0x20;
+
+    if (fr->IDE != CAN_IDE_STD)
+        return 0;
+
+    if ((fr->EID < base) ||
+        (fr->EID > base + CAN_IOBOX_LAST_IN))
+        return 0;
+
+    if ((fr->EID == base + CAN_IOBOX_PING) && (fr->DLC == 0))
+    {
+        CanTxTyped<iobox_whoami> frame(base + CAN_IOBOX_WHOAMI, false);
+
+        frame.get().version = 1;
+        // PWM clock periods in 0.01 uS, equal to clock freq / 100 * 1000
+        frame.get().pwm_period = 5000;
+        // Tach-in clock periods in 0.01 uS, equal to clock freq / 100 * 1000
+        frame.get().tachin_period = 66;
+
+        return 0;
+    }
+    else if (fr->EID == base + CAN_IOBOX_CONFIG)
+    {
+        const iobox_cfg *cfg = reinterpret_cast<const iobox_cfg *>(fr->data8);
+
+        //can0       201   [8]  00 00 00 00 14 14 00 00
+        pwm_mask = cfg->pwm_mask;
+        tachin_mask = cfg->tachin_mask;
+        adc_broadcast_interval = cfg->adc_broadcast_interval;
+        tach_broadcast_interval = cfg->tach_broadcast_interval;
+
+        configured = true;
+
+        return 0;
+    }
+    else if ((fr->EID > base + CAN_IOBOX_SET_PWM(0)) &&
+             (fr->EID < base + CAN_IOBOX_SET_PWM(2)))
+    {
+        const iobox_pwm *pwm = reinterpret_cast<const iobox_pwm *>(fr->data8);
+
+        /* TODO: PWM periods */
+        return 0;
+    }
+    else if (fr->EID == base + CAN_IOBOX_SET_PWM(3))
+    {
+        const iobox_pwm_last *pwm = reinterpret_cast<const iobox_pwm_last *>(fr->data8);
+
+        /* TODO: PWM periods and outputs */
+        return 0;
+    }
+
+    /* Should not happen */
+    return -1;
+}
+
+int CanIoBoxTx(void)
+{
+    if (!configured)
+        return 0;
+
+    const uint32_t base = CAN_IOBOX_BASE0 + iobox_index * 0x20;
+
+    if (1) {
+        CanTxTyped<iobox_adc14> frame(base + CAN_IOBOX_ADC14, false);
+
+        for (size_t i = 0; i < 4; i++) {
+            frame.get().adc[i] = CanIoBoxGetAdc(i);
+        }
+    }
+    if (1) {
+        CanTxTyped<iobox_adc57> frame(base + CAN_IOBOX_ADC57, false);
+
+        for (size_t i = 0; i < 3; i++) {
+            frame.get().adc[i] = CanIoBoxGetAdc(4 + i);
+        }
+    }
+}

--- a/firmware/can_iobox.h
+++ b/firmware/can_iobox.h
@@ -1,0 +1,3 @@
+#pragma once
+
+int CanIoBoxRx(const CANRxFrame *fr);

--- a/firmware/console/binary/tunerstudio.cpp
+++ b/firmware/console/binary/tunerstudio.cpp
@@ -231,6 +231,14 @@ static void handleIoTestCommand(TsChannelBase* tsChannel, ts_response_format_e m
 		rebootToOpenblt();
 		break;
 
+	case 0xbd:
+		ResetConfiguration();
+		SetConfiguration();
+		/* Send ok to make TS happy, wait until sent */
+		sendOkResponse(tsChannel, TS_CRC);
+		chThdSleepMilliseconds(100);
+		rebootNow();
+
 	default:
 		tunerStudioError(tsChannel, "Unexpected IoTest command");
 	}

--- a/firmware/console/binary/tunerstudio.cpp
+++ b/firmware/console/binary/tunerstudio.cpp
@@ -204,7 +204,7 @@ static void handleBurnCommand(TsChannelBase* tsChannel, ts_response_format_e mod
 	sendResponseCode(mode, tsChannel, TS_RESPONSE_BURN_OK);
 }
 
-static void handleIoTestCommand(TsChannelBase* tsChannel, ts_response_format_e mode, uint16_t subsystem, uint16_t /* index */) {
+static void handleIoTestCommand(TsChannelBase* tsChannel, ts_response_format_e mode, uint16_t subsystem, uint16_t index) {
 	/* index is not used yet */
 
 	switch (subsystem) {
@@ -232,7 +232,7 @@ static void handleIoTestCommand(TsChannelBase* tsChannel, ts_response_format_e m
 		break;
 
 	case 0xbd:
-		ResetConfiguration();
+		ResetConfiguration(index);
 		SetConfiguration();
 		/* Send ok to make TS happy, wait until sent */
 		sendOkResponse(tsChannel, TS_CRC);

--- a/firmware/ini/wideband_dual.ini
+++ b/firmware/ini/wideband_dual.ini
@@ -349,6 +349,7 @@ menuDialog = main
 
    menu = "&Controller"
       subMenu = ecuTools, "ECU tools"
+      subMenu = ecuPresets, "Presets"
 
 [ControllerCommands]
 ; commandName    = command1, command2, commandn...
@@ -368,6 +369,12 @@ cmd_dfu                      = "Z\x00\xba\x00\x00"
 cmd_openblt                  = "Z\x00\xbc\x00\x00"
 ; reset settings to default
 cmd_defaults                 = "Z\x00\xbd\x00\x00"
+; reset settings to presets
+cmd_defaultsAemNet           = "Z\x00\xbd\x00\x01"
+cmd_defaultsAemNetAfrOnly    = "Z\x00\xbd\x00\x02"
+cmd_defaultsAemNetIoBox0     = "Z\x00\xbd\x00\x10"
+cmd_defaultsAemNetIoBox1     = "Z\x00\xbd\x00\x11"
+cmd_defaultsAemNetIoBox2     = "Z\x00\xbd\x00\x12"
 
 [UserDefined]
 
@@ -434,11 +441,20 @@ dialog = ecuReset, "Reset"
    commandButton = "Reset to DFU", cmd_dfu
    commandButton = "Reset to OpenBLT", cmd_openblt
 
-dialog = ecuDefaults, "Default settings"
-   commandButton = "Load default & restart", cmd_defaults, { 1 }, showMessageOnClick, "Please restart TunerStudio to update settings"
-
 dialog = ecuTools, "ECU tools and Commands", xAxis
    panel = ecuReset
+
+dialog = ecuDefaults, "Pre-defined settings"
+   field = "ECU will restart after new settings appied"
+   commandButton = "Defaults", cmd_defaults, { 1 }, showMessageOnClick, "Please restart TunerStudio to update settings"
+   commandButton = "AEMNet AFR and EGT", cmd_defaultsAemNet, { 1 }, showMessageOnClick, "Please restart TunerStudio to update settings"
+   commandButton = "AEMNet AFR only", cmd_defaultsAemNetAfrOnly, { 1 }, showMessageOnClick, "Please restart TunerStudio to update settings"
+   field = "Special modes"
+   commandButton = "IO Box #0 (0x200) (DAC only)", cmd_defaultsAemNetIoBox0, { 1 }, showMessageOnClick, "Please restart TunerStudio to update settings"
+   commandButton = "IO Box #1 (0x220) (DAC only)", cmd_defaultsAemNetIoBox1, { 1 }, showMessageOnClick, "Please restart TunerStudio to update settings"
+   commandButton = "IO Box #2 (0x240) (DAC only)", cmd_defaultsAemNetIoBox2, { 1 }, showMessageOnClick, "Please restart TunerStudio to update settings"
+
+dialog = ecuPresets, "Presets", xAxis
    panel = ecuDefaults
 
 [Tools]

--- a/firmware/ini/wideband_dual.ini
+++ b/firmware/ini/wideband_dual.ini
@@ -12,12 +12,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-   signature      = "rusEFI 2024.02.11.wideband_dual"
+   signature      = "rusEFI 2025.02.04.wideband_dual"
 
 [TunerStudio]
    queryCommand   = "S"
    versionInfo    = "V"  ; firmware version for title bar.
-   signature      = "rusEFI 2024.02.11.wideband_dual" ; signature is expected to be 7 or more characters.
+   signature      = "rusEFI 2025.02.04.wideband_dual" ; signature is expected to be 7 or more characters.
 
    ; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
    useLegacyFTempUnits = false

--- a/firmware/ini/wideband_dual.ini
+++ b/firmware/ini/wideband_dual.ini
@@ -65,8 +65,8 @@ Aux0OutBins    =  array,  F32,      5,     [8],    "",     1,         0,   0,  1
 Aux1OutBins    =  array,  F32,     37,     [8],    "",     1,         0,   0,  1500,      2
 Aux0Out        =  array,  F32,     69,     [8],   "V",     1,         0,   0,   5.0,      2
 Aux1Out        =  array,  F32,    101,     [8],   "V",     1,         0,   0,   5.0,      2
-Aux0InputSel   = bits,    U08,    133,   [0:3], "AFR 0", "AFR 1", "Lambda 0", "Lambda 1", "EGT 0", "EGT 1"
-Aux1InputSel   = bits,    U08,    134,   [0:3], "AFR 0", "AFR 1", "Lambda 0", "Lambda 1", "EGT 0", "EGT 1"
+Aux0InputSel   = bits,    U08,    133,   [0:2], "AFR 0", "AFR 1", "Lambda 0", "Lambda 1", "EGT 0", "EGT 1", "CAN input", "INVALID"
+Aux1InputSel   = bits,    U08,    134,   [0:2], "AFR 0", "AFR 1", "Lambda 0", "Lambda 1", "EGT 0", "EGT 1", "CAN input", "INVALID"
 LsuSensorType  = bits,    U08,    135,   [0:2], "LSU 4.9", "LSU 4.2", "LSU ADV", "INVALID", "INVALID", "INVALID", "INVALID", "INVALID"
 
 RusEfiTx0      = bits,    U08,    136,   [0:0], "Disable", "Enable"
@@ -86,6 +86,12 @@ AemNetIdEgOff0 = scalar,  U08,    154,             "",     1,         0,   0,  2
 
 AemNetEgtTx1   = bits,    U08,    160,   [2:2], "Disable", "Enable"
 AemNetIdEgOff1 = scalar,  U08,    162,             "",     1,         0,   0,  255,       0
+
+IoBoxIndex     = bits,    U08,    168,   [0:1], "IoBox0 (0x200)", "IoBox1 (0x220)", "IoBox2 (0x240)", "Custom"
+IoBoxRx        = bits,    U08,    169,   [0:0], "Disable", "Enable"
+IoBoxTx        = bits,    U08,    169,   [1:1], "Disable", "Enable"
+IoBoxCanIde    = bits,    U08,    169,   [2:2], "Standart", "Extended"
+IoBoxCanId     = scalar,  U32,    172,             "",     1,         0,   0, 1073741823, 0
 
 page     = 2 ; this is a RAM only page with no burnable flash
 ; name         =  class, type, offset, [shape], units, scale, translate, min,   max, digits
@@ -335,6 +341,7 @@ menuDialog = main
       subMenu = sensor_settings, "Sensor settings"
       subMenu = can_settings, "CAN AFR settings"
       subMenu = can_egt_settings, "CAN EGT settings"
+      subMenu = can_iobox_settings, "CAN IO Box settings"
 
    menu = "Outputs"
       subMenu = auxOut0, "AUX analog output 0"
@@ -359,6 +366,8 @@ cmd_reset_controller         = "Z\x00\xbb\x00\x00"
 cmd_dfu                      = "Z\x00\xba\x00\x00"
 ; restart to OpenBlt
 cmd_openblt                  = "Z\x00\xbc\x00\x00"
+; reset settings to default
+cmd_defaults                 = "Z\x00\xbd\x00\x00"
 
 [UserDefined]
 
@@ -405,20 +414,31 @@ dialog = can_egt_settings, "CAN AFR Settings", border
    panel = egt0_can_settings, West
    panel = egt1_can_settings, East
 
+dialog = can_iobox_settings, "CAN IO Box Settings"
+   field = "IoBox index", IoBoxIndex
+   field = "Custom CAN ID", IoBoxCanId, { IoBoxIndex >= 3 }
+   field = "Custom CAN ID type", IoBoxCanIde, { IoBoxIndex >= 3 }, { 1 }, displayInHex
+   field = "Enable CAN Rx", IoBoxRx
+   field = "Enable CAN Tx", IoBoxTx
+
 dialog = auxOut0, "AUX analog out 0 Settings"
    field = "Signal", Aux0InputSel
-   panel = auxOut0Curve
+   panel = auxOut0Curve, Center, { Aux0InputSel <= 5}
 
 dialog = auxOut1, "AUX analog out 1 Settings"
    field = "Signal", Aux1InputSel
-   panel = auxOut1Curve
+   panel = auxOut1Curve, Center, { Aux1InputSel <= 5}
 
 dialog = ecuReset, "Reset"
    commandButton = "Reset ECU", cmd_reset_controller
    commandButton = "Reset to DFU", cmd_dfu
    commandButton = "Reset to OpenBLT", cmd_openblt
 
+dialog = ecuDefaults, "Default settings"
+   commandButton = "Load default & restart", cmd_defaults, { 1 }, showMessageOnClick, "Please restart TunerStudio to update settings"
+
 dialog = ecuTools, "ECU tools and Commands", xAxis
    panel = ecuReset
+   panel = ecuDefaults
 
 [Tools]

--- a/firmware/ini/wideband_f1.ini
+++ b/firmware/ini/wideband_f1.ini
@@ -12,12 +12,12 @@ enable2ndByteCanID = false
 
 [MegaTune]
  ; https://rusefi.com/forum/viewtopic.php?p=36201#p36201
-   signature      = "rusEFI 2023.05.10.wideband_f1"
+   signature      = "rusEFI 2025.02.04.wideband_f1"
 
 [TunerStudio]
    queryCommand   = "S"
    versionInfo    = "V"  ; firmware version for title bar.
-   signature      = "rusEFI 2023.05.10.wideband_f1" ; signature is expected to be 7 or more characters.
+   signature      = "rusEFI 2025.02.04.wideband_f1" ; signature is expected to be 7 or more characters.
 
    ; TS will try to use legacy temp units in some cases, showing "deg F" on a CLT gauge that's actually deg C
    useLegacyFTempUnits = false

--- a/firmware/test_can_dac.sh
+++ b/firmware/test_can_dac.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+INTERFACE=can0
+# base 0x200, base+2 = PWM1,2 periods packet
+CANID=202
+#See http://www.msextra.com/doc/pdf/Microsquirt-IObox-1.pdf for protocol specification
+# Note BIG-endian values
+
+while true; do
+	# zero
+	cansend $INTERFACE ${CANID}#0000.ffff.0000.ffff
+	sleep 1
+	# half
+	cansend $INTERFACE ${CANID}#ff7f.ff7f.ff7f.ff7f
+	sleep 1
+	#full
+	cansend $INTERFACE ${CANID}#ffff.0000.ffff.0000
+	sleep 1
+done


### PR DESCRIPTION
This adds support of driving AUX DAC outputs over CAN using MS IO Box protocol.
See http://www.msextra.com/doc/pdf/Microsquirt-IObox-1.pdf
![Screenshot from 2025-02-04 22-43-57](https://github.com/user-attachments/assets/c93f8d33-9f92-4c1a-a8c3-132d72f4dc3f)
