### PR TITLE
Add heater control parameters to TunerStudio

### DIFF
--- a/firmware/boards/port.h
+++ b/firmware/boards/port.h
@@ -5,6 +5,7 @@
 
 #include "port_shared.h"
 #include "wideband_config.h"
+#include "heater_control.h"
 
 struct AnalogChannelResult
 {
@@ -57,7 +58,7 @@ class Configuration {
 private:
     // Increment this any time the configuration format changes
     // It is stored along with the data to ensure that it has been written before
-    static constexpr uint32_t ExpectedTag = 0xDEADBE02;
+    static constexpr uint32_t ExpectedTag = 0xDEADBE03;
     uint32_t Tag = ExpectedTag;
 
 public:
@@ -107,6 +108,10 @@ public:
             egt[i].AemNetIdOffset = i;
         }
 
+        heaterConfig.HeaterSupplyOffVoltage = HEATER_SUPPLY_OFF_VOLTAGE;
+        heaterConfig.HeaterSupplyOnVoltage = HEATER_SUPPLY_ON_VOLTAGE;
+        heaterConfig.PreheatTimeSec = HEATER_PREHEAT_TIME;
+        
         /* Finaly */
         Tag = ExpectedTag;
     }
@@ -143,12 +148,15 @@ public:
                 uint8_t AemNetIdOffset;
                 uint8_t pad[5];
             } egt[2];
+
+            struct HeaterConfig heaterConfig;
         } __attribute__((packed));
 
         // pad to 256 bytes including tag
         uint8_t pad[256 - sizeof(Tag)];
     };
 };
+static_assert(sizeof(Configuration) == 256, "Configuration size incorrect");
 
 int InitConfiguration();
 Configuration* GetConfiguration();

--- a/firmware/heater_control.h
+++ b/firmware/heater_control.h
@@ -7,6 +7,7 @@
 #include "can.h"
 #include "pid.h"
 #include "timer.h"
+#include "fixed_point.h"
 
 enum class HeaterState
 {
@@ -16,6 +17,14 @@ enum class HeaterState
     Stopped,
     NoHeaterSupply,
 };
+
+struct HeaterConfig {
+    FixedPoint<uint8_t, 10> HeaterSupplyOffVoltage; // in 0.1V steps, 25.5V max
+    FixedPoint<uint8_t, 10> HeaterSupplyOnVoltage;  // in 0.1V steps, 25.5V max
+    ScaledValue<uint8_t, 5> PreheatTimeSec; // In 5 second steps, 1275s max
+    uint8_t pad[5];
+} __attribute__((packed));
+static_assert(sizeof(HeaterConfig) == 8, "HeaterConfig size incorrect");
 
 struct ISampler;
 
@@ -31,8 +40,8 @@ struct IHeaterController
 class HeaterControllerBase : public IHeaterController
 {
 public:
-    HeaterControllerBase(int ch, int preheatTimeSec, int warmupTimeSec);
-    void Configure(float targetTempC, float targetEsr);
+    HeaterControllerBase(int ch);
+    void Configure(float targetTempC, float targetEsr, struct HeaterConfig* configuration);
     void Update(const ISampler& sampler, HeaterAllow heaterAllowState) override;
 
     bool IsRunningClosedLoop() const override;
@@ -62,9 +71,6 @@ private:
 
     const uint8_t ch;
 
-    const int m_preheatTimeSec;
-    const int m_warmupTimeSec;
-
     int m_retryTime = 0;
 
     Timer m_heaterStableTimer;
@@ -79,7 +85,7 @@ private:
     Timer m_underheatTimer;
     Timer m_overheatTimer;
 
-    static const int batteryStabTimeCounter = HEATER_BATTERY_STAB_TIME / HEATER_CONTROL_PERIOD;
+    struct HeaterConfig* m_configuration;
 };
 
 const IHeaterController& GetHeaterController(int ch);

--- a/firmware/heater_thread.cpp
+++ b/firmware/heater_thread.cpp
@@ -28,7 +28,7 @@ static const PWMConfig heaterPwmConfig = {
 class HeaterController : public HeaterControllerBase {
 public:
     HeaterController(int ch, int pwm_ch)
-        : HeaterControllerBase(ch, HEATER_PREHEAT_TIME, HEATER_WARMUP_TIMEOUT)
+        : HeaterControllerBase(ch)
         , pwm_ch(pwm_ch)
     {
     }
@@ -74,21 +74,24 @@ static void HeaterThread(void*)
     // immediately think we overshot the target temperature
     chThdSleepMilliseconds(1000);
 
+    struct HeaterConfig* configuration = &GetConfiguration()->heaterConfig;
+
     // Configure heater controllers for sensor type
     for (int i = 0; i < AFR_CHANNELS; i++)
     {
         auto& h = heaterControllers[i];
+
         switch (GetSensorType())
         {
             case SensorType::LSU42:
-                h.Configure(730, 80);
+                h.Configure(730, 80, configuration);
                 break;
             case SensorType::LSUADV:
-                h.Configure(785, 300);
+                h.Configure(785, 300, configuration);
                 break;
             case SensorType::LSU49:
             default:
-                h.Configure(780, 300);
+                h.Configure(780, 300, configuration);
                 break;
         }
     }

--- a/firmware/ini/wideband_dual.ini
+++ b/firmware/ini/wideband_dual.ini
@@ -85,7 +85,11 @@ AemNetEgtTx0   = bits,    U08,    152,   [2:2], "Disable", "Enable"
 AemNetEgtIdx0  = scalar,  U08,    154,             "",     1,         0,   0,  255,       0
 
 AemNetEgtTx1   = bits,    U08,    160,   [2:2], "Disable", "Enable"
-AemNetEgtIdx1 = scalar,  U08,    162,             "",     1,         0,   0,  255,       0
+AemNetEgtIdx1  = scalar,  U08,    162,             "",     1,         0,   0,  255,       0
+
+HeaterSupplyOffVoltage = scalar, U08,    168,           "V",    0.1,      0,   0,   24.0,     2
+HeaterSupplyOnVoltage  = scalar, U08,    169,           "V",    0.1,      0,   0,   24.0,     2
+PreheatTimeSec         = scalar, U08,    170,           "s",    5,        0,   0,   1275,     0
 
 page     = 2 ; this is a RAM only page with no burnable flash
 ; name         =  class, type, offset, [shape], units, scale, translate, min,   max, digits
@@ -333,6 +337,7 @@ entry = EGT1_commErrors,     "EGT 1: comm errors",   int, "%d"
 menuDialog = main
    menu = "&Settings"
       subMenu = sensor_settings, "Sensor settings"
+      subMenu = heater_settings, "Heater settings"
       subMenu = can_settings, "CAN AFR settings"
       subMenu = can_egt_settings, "CAN EGT settings"
 
@@ -364,6 +369,11 @@ cmd_openblt                  = "Z\x00\xbc\x00\x00"
 
 dialog = sensor_settings, "Sensor Settings"
    field = "Sensor Type", LsuSensorType
+
+dialog = heater_settings, "Heater Settings"
+   field = "Heater Supply Off Voltage", HeaterSupplyOffVoltage
+   field = "Heater Supply On Voltage", HeaterSupplyOnVoltage
+   field = "Preheat Time Sec", PreheatTimeSec
 
 dialog = afr0_can_settings, "AFR 0 (left) channel CAN Settings"
    field = "RusEFI protocol:"

--- a/firmware/util/fixed_point.h
+++ b/firmware/util/fixed_point.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <cstdint>
+#include <type_traits>
+#include <limits>
+
+/**
+ * @brief A lightweight class for storing scaled values using a base type with ratio scale factor.
+ * 
+ * This class is designed to be compatible with packed structures
+ * 
+ * Examples:
+ * - ScaledValue<int16_t, 10> multiplies raw values by 10.0 (e.g., 13 raw -> 130.0f)
+ * - ScaledValue<int16_t, 1, 10> multiplies raw values by 0.1 (e.g., 128 raw -> 12.8f)
+ * 
+ * @tparam TStorage Base type for storage (e.g., int8_t, uint8_t, int16_t, uint16_t, etc.).
+ * @tparam TScaleFactorNumerator Numerator of the scale factor (e.g., 10 for scale 10.0).
+ * @tparam TScaleFactorDenominator Denominator of the scale factor (e.g., 10 for scale 0.1).
+ */
+template<typename TStorage, uint16_t TScaleFactorNumerator, uint16_t TScaleFactorDenominator = 1>
+struct ScaledValue {
+    static_assert(std::is_integral<TStorage>::value, "TStorage must be an integral type");
+    static_assert(TScaleFactorDenominator != 0, "TScaleFactorDenominator must not be zero");
+
+    static constexpr float scale() {
+        return static_cast<float>(TScaleFactorNumerator) / static_cast<float>(TScaleFactorDenominator);
+    }
+
+    TStorage value; // Storage using the base type
+
+    // Convert to float
+    constexpr float getValue() const {
+        return static_cast<float>(value) * scale();
+    }
+
+    // Convert from float
+    constexpr void setValue(float val) {
+        float scaled = val / scale();
+        if (scaled < minRawValue()) {
+            value = minRawValue();
+            return;
+        }
+        if (scaled > maxRawValue()) {
+            value = maxRawValue();
+            return;
+        }
+        value = static_cast<TStorage>(scaled + (scaled >= 0 ? 0.5f : -0.5f)); // Round to nearest
+    }
+
+    constexpr TStorage getRaw() const {
+        return value;
+    }
+
+    constexpr void setRaw(TStorage raw) {
+        value = raw;
+    }
+
+    // Implicit conversion to float
+    constexpr operator float() const {
+        return getValue();
+    }
+
+    // Implicit assignment from float
+    constexpr ScaledValue& operator=(float val) {
+        setValue(val);
+        return *this;
+    }
+
+private:
+    // Maximum raw value that can be stored
+    constexpr TStorage maxRawValue() const {
+        return std::numeric_limits<TStorage>::max();
+    }
+
+    // Minimum raw value that can be stored
+    constexpr TStorage minRawValue() const {
+        return std::numeric_limits<TStorage>::min();
+    }
+};
+
+// Alias for fixed-point
+template<typename TStorage, int TScaleFactor>
+using FixedPoint = ScaledValue<TStorage, 1, TScaleFactor>;

--- a/test/Makefile
+++ b/test/Makefile
@@ -30,6 +30,8 @@ CPPSRC += \
 	test_stubs.cpp \
 	tests/test_sampler.cpp \
 	tests/test_heater.cpp \
+	tests/test_fixed_point.cpp \
+	tests/test_config.cpp \
 
 INCDIR += \
 	$(PROJECT_DIR)/googletest/googlemock/ \

--- a/test/tests/test_config.cpp
+++ b/test/tests/test_config.cpp
@@ -1,0 +1,220 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <cstring>
+#include "fixed_point.h"
+#include "port.h"
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-const-variable"
+namespace ConfigSizes {
+    constexpr size_t TAG = 4;
+    constexpr size_t NO_LONGER_USED_0 = 1;
+    constexpr size_t AUX_OUT_BINS = 64;
+    constexpr size_t AUX_OUT_VALUES = 64;
+    constexpr size_t AUX_OUTPUT_SOURCE = 2;
+    constexpr size_t SENSOR_TYPE = 1;
+    constexpr size_t AFR_CHANNEL = 8;
+    constexpr size_t AFR_SETTINGS = AFR_CHANNEL * 2;
+    constexpr size_t EGT_CHANNEL = 8;
+    constexpr size_t EGT_SETTINGS = EGT_CHANNEL * 2;
+    constexpr size_t HEATER_CONFIG = 8;
+}
+#pragma GCC diagnostic pop
+
+template<typename T>
+void WriteAtOffset(Configuration& config, size_t offset, T value) {
+    uint8_t* bytes = reinterpret_cast<uint8_t*>(&config);
+    std::memcpy(bytes + offset, &value, sizeof(T));
+}
+
+TEST(ConfigLayout, BinaryCompatibility_NoLongerUsed0) {
+    Configuration config = {};
+    
+    size_t offset = ConfigSizes::TAG;
+    uint8_t expectedValue = 0x42;
+    WriteAtOffset(config, offset, expectedValue);
+    
+    EXPECT_EQ(config.NoLongerUsed0, expectedValue);
+}
+
+TEST(ConfigLayout, BinaryCompatibility_AuxOutBins) {
+    Configuration config = {};
+
+    size_t offset = ConfigSizes::TAG
+                  + ConfigSizes::NO_LONGER_USED_0;
+    
+    // Test auxOutBins[0]
+    for (int i = 0; i < 8; i++) {
+        float testValue = 10.0f + i;
+        WriteAtOffset(config, offset + i * sizeof(float), testValue);
+    }
+    
+    for (int i = 0; i < 8; i++) {
+        EXPECT_FLOAT_EQ(config.auxOutBins[0][i], 10.0f + i);
+    }
+
+    // Test auxOutBins[1]
+    offset += 8 * sizeof(float);
+    for (int i = 0; i < 8; i++) {
+        float testValue = 20.0f + i;
+        WriteAtOffset(config, offset + i * sizeof(float), testValue);
+    }
+
+    for (int i = 0; i < 8; i++) {
+        EXPECT_FLOAT_EQ(config.auxOutBins[1][i], 20.0f + i);
+    }
+}
+
+TEST(ConfigLayout, BinaryCompatibility_AuxOutValues) {
+    Configuration config = {};
+
+    size_t offset = ConfigSizes::TAG
+                  + ConfigSizes::NO_LONGER_USED_0
+                  + ConfigSizes::AUX_OUT_BINS;
+
+    for (int j = 0; j < 2; j++) {
+        for (int i = 0; i < 8; i++) {
+            float testValue = 100.0f + j * 10 + i;
+            WriteAtOffset(config, offset + (j * 8 + i) * sizeof(float), testValue);
+        }
+    }
+
+    for (int j = 0; j < 2; j++) {
+        for (int i = 0; i < 8; i++) {
+            EXPECT_FLOAT_EQ(config.auxOutValues[j][i], 100.0f + j * 10 + i);
+        }
+    }
+}
+
+TEST(ConfigLayout, BinaryCompatibility_AuxOutputSource) {
+    Configuration config = {};
+
+    size_t offset = ConfigSizes::TAG
+                  + ConfigSizes::NO_LONGER_USED_0
+                  + ConfigSizes::AUX_OUT_BINS
+                  + ConfigSizes::AUX_OUT_VALUES;
+    
+    WriteAtOffset(config, offset, static_cast<uint8_t>(AuxOutputMode::Lambda0));
+    WriteAtOffset(config, offset + 1, static_cast<uint8_t>(AuxOutputMode::Egt1));
+    
+    EXPECT_EQ(config.auxOutputSource[0], AuxOutputMode::Lambda0);
+    EXPECT_EQ(config.auxOutputSource[1], AuxOutputMode::Egt1);
+}
+
+TEST(ConfigLayout, BinaryCompatibility_SensorType) {
+    Configuration config = {};
+    
+    size_t offset = ConfigSizes::TAG
+                  + ConfigSizes::NO_LONGER_USED_0
+                  + ConfigSizes::AUX_OUT_BINS
+                  + ConfigSizes::AUX_OUT_VALUES
+                  + ConfigSizes::AUX_OUTPUT_SOURCE;
+    
+    WriteAtOffset(config, offset, static_cast<uint8_t>(SensorType::LSU42));
+    
+    EXPECT_EQ(config.sensorType, SensorType::LSU42);
+}
+
+TEST(ConfigLayout, BinaryCompatibility_AfrChannelSettings) {
+    Configuration config = {};
+    
+    size_t offset = ConfigSizes::TAG
+                  + ConfigSizes::NO_LONGER_USED_0
+                  + ConfigSizes::AUX_OUT_BINS
+                  + ConfigSizes::AUX_OUT_VALUES
+                  + ConfigSizes::AUX_OUTPUT_SOURCE
+                  + ConfigSizes::SENSOR_TYPE;
+    
+    // Write first AFR channel
+    uint8_t bitfield0 = 0b00000111; // RusEfiTx=1, RusEfiTxDiag=1, AemNetTx=1
+    WriteAtOffset(config, offset, bitfield0);
+    WriteAtOffset(config, offset + 1, static_cast<uint8_t>(5)); // RusEfiIdx
+    WriteAtOffset(config, offset + 2, static_cast<uint8_t>(10)); // AemNetIdOffset
+    
+    EXPECT_TRUE(config.afr[0].RusEfiTx);
+    EXPECT_TRUE(config.afr[0].RusEfiTxDiag);
+    EXPECT_TRUE(config.afr[0].AemNetTx);
+    EXPECT_EQ(config.afr[0].RusEfiIdx, 5);
+    EXPECT_EQ(config.afr[0].AemNetIdOffset, 10);
+    
+    // Write second AFR channel
+    offset += ConfigSizes::AFR_CHANNEL;
+    uint8_t bitfield1 = 0b00000010; // RusEfiTx=0, RusEfiTxDiag=1, AemNetTx=0
+    WriteAtOffset(config, offset, bitfield1);
+    WriteAtOffset(config, offset + 1, static_cast<uint8_t>(7)); // RusEfiIdx
+    WriteAtOffset(config, offset + 2, static_cast<uint8_t>(15)); // AemNetIdOffset
+    
+    EXPECT_FALSE(config.afr[1].RusEfiTx);
+    EXPECT_TRUE(config.afr[1].RusEfiTxDiag);
+    EXPECT_FALSE(config.afr[1].AemNetTx);
+    EXPECT_EQ(config.afr[1].RusEfiIdx, 7);
+    EXPECT_EQ(config.afr[1].AemNetIdOffset, 15);
+}
+
+TEST(ConfigLayout, BinaryCompatibility_EgtChannelSettings) {
+    Configuration config = {};
+
+    size_t offset = ConfigSizes::TAG
+                  + ConfigSizes::NO_LONGER_USED_0
+                  + ConfigSizes::AUX_OUT_BINS
+                  + ConfigSizes::AUX_OUT_VALUES
+                  + ConfigSizes::AUX_OUTPUT_SOURCE
+                  + ConfigSizes::SENSOR_TYPE
+                  + ConfigSizes::AFR_SETTINGS;
+    
+    // Write first EGT channel
+    uint8_t bitfield0 = 0b00000101; // RusEfiTx=1, RusEfiTxDiag=0, AemNetTx=1
+    WriteAtOffset(config, offset, bitfield0);
+    WriteAtOffset(config, offset + 1, static_cast<uint8_t>(3)); // RusEfiIdx
+    WriteAtOffset(config, offset + 2, static_cast<uint8_t>(8)); // AemNetIdOffset
+    
+    EXPECT_TRUE(config.egt[0].RusEfiTx);
+    EXPECT_FALSE(config.egt[0].RusEfiTxDiag);
+    EXPECT_TRUE(config.egt[0].AemNetTx);
+    EXPECT_EQ(config.egt[0].RusEfiIdx, 3);
+    EXPECT_EQ(config.egt[0].AemNetIdOffset, 8);
+
+    // Write second EGT channel
+    offset += ConfigSizes::EGT_CHANNEL;
+    uint8_t bitfield1 = 0b00000010; // RusEfiTx=0, RusEfiTxDiag=1, AemNetTx=0
+    WriteAtOffset(config, offset, bitfield1);
+    WriteAtOffset(config, offset + 1, static_cast<uint8_t>(7)); // RusEfiIdx
+    WriteAtOffset(config, offset + 2, static_cast<uint8_t>(15)); // AemNetIdOffset
+    
+    EXPECT_FALSE(config.egt[1].RusEfiTx);
+    EXPECT_TRUE(config.egt[1].RusEfiTxDiag);
+    EXPECT_FALSE(config.egt[1].AemNetTx);
+    EXPECT_EQ(config.egt[1].RusEfiIdx, 7);
+    EXPECT_EQ(config.egt[1].AemNetIdOffset, 15);
+}
+
+TEST(ConfigLayout, BinaryCompatibility_HeaterConfig) {
+    Configuration config = {};
+
+    size_t offset = ConfigSizes::TAG
+                  + ConfigSizes::NO_LONGER_USED_0
+                  + ConfigSizes::AUX_OUT_BINS
+                  + ConfigSizes::AUX_OUT_VALUES
+                  + ConfigSizes::AUX_OUTPUT_SOURCE
+                  + ConfigSizes::SENSOR_TYPE
+                  + ConfigSizes::AFR_SETTINGS
+                  + ConfigSizes::EGT_SETTINGS;
+    
+    WriteAtOffset(config, offset++, static_cast<uint8_t>(120)); // HeaterSupplyOffVoltage
+    WriteAtOffset(config, offset++, static_cast<uint8_t>(135)); // HeaterSupplyOnVoltage
+    WriteAtOffset(config, offset++, static_cast<uint8_t>(25)); // PreheatTimeSec
+    
+    EXPECT_FLOAT_EQ(config.heaterConfig.HeaterSupplyOffVoltage.getValue(), 12.0f);
+    EXPECT_FLOAT_EQ(config.heaterConfig.HeaterSupplyOnVoltage.getValue(), 13.5f);
+    EXPECT_FLOAT_EQ(config.heaterConfig.PreheatTimeSec, 125.0f);
+}
+
+TEST(ConfigLayout, SizeVerification) {
+    // Verify the total size is exactly 256 bytes
+    EXPECT_EQ(sizeof(Configuration), 256UL);
+    
+    // Verify union size
+    Configuration config;
+    EXPECT_EQ(sizeof(config.pad), 252UL); // 256 - 4 (Tag size)
+}

--- a/test/tests/test_fixed_point.cpp
+++ b/test/tests/test_fixed_point.cpp
@@ -1,0 +1,223 @@
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <limits>
+#include "util/fixed_point.h"
+
+// Test that ScaledValue has the same size as TStorage (no overhead)
+TEST(FixedPointTest, SizeCheck) {
+    EXPECT_EQ(sizeof(ScaledValue<int8_t, 10, 1>), sizeof(int8_t));
+    EXPECT_EQ(sizeof(ScaledValue<uint8_t, 10, 1>), sizeof(uint8_t));
+    EXPECT_EQ(sizeof(ScaledValue<int16_t, 10, 1>), sizeof(int16_t));
+    EXPECT_EQ(sizeof(ScaledValue<uint16_t, 10, 1>), sizeof(uint16_t));
+    EXPECT_EQ(sizeof(ScaledValue<int32_t, 10, 1>), sizeof(int32_t));
+    EXPECT_EQ(sizeof(ScaledValue<uint32_t, 10, 1>), sizeof(uint32_t));
+
+    // Test with different scale factors
+    EXPECT_EQ(sizeof(ScaledValue<int16_t, 1, 10>), sizeof(int16_t));
+    EXPECT_EQ(sizeof(ScaledValue<int16_t, 1, 5>), sizeof(int16_t));
+    EXPECT_EQ(sizeof(ScaledValue<int16_t, 10, 1>), sizeof(int16_t));
+}
+
+// Test alias
+TEST(FixedPointTest, AliasSizeCheck) {
+    EXPECT_EQ(sizeof(FixedPoint<int8_t, 10>), sizeof(int8_t));
+    EXPECT_EQ(sizeof(FixedPoint<int16_t, 10>), sizeof(int16_t));
+    EXPECT_EQ(sizeof(FixedPoint<int32_t, 10>), sizeof(int32_t));
+}
+
+// Test scaling with factor < 1.0
+TEST(FixedPointTest, ScaleFactorLessThanOne) {
+    ScaledValue<int16_t, 1, 10> value;
+    
+    // Test setValue/getValue
+    value.setValue(12.8f);
+    EXPECT_EQ(value.getRaw(), 128);
+    EXPECT_FLOAT_EQ(value.getValue(), 12.8f);
+    
+    value.setValue(5.0f);
+    EXPECT_EQ(value.getRaw(), 50);
+    EXPECT_FLOAT_EQ(value.getValue(), 5.0f);
+    
+    // Test implicit conversion
+    value = 3.14f;
+    EXPECT_EQ(value.getRaw(), 31);  // Rounded
+    EXPECT_NEAR(static_cast<float>(value), 3.1f, 0.1f);
+}
+
+// Test scaling with factor > 1.0
+TEST(FixedPointTest, ScaleFactorMoreThanOne) {
+    ScaledValue<int16_t, 10> value;
+    
+    // Test setValue/getValue
+    value.setValue(128.0f);
+    EXPECT_EQ(value.getRaw(), 13);  // 128 * 0.1 = 12.8, rounded to 13
+    EXPECT_NEAR(value.getValue(), 130.0f, 1.0f);
+    
+    value.setValue(100.0f);
+    EXPECT_EQ(value.getRaw(), 10);
+    EXPECT_FLOAT_EQ(value.getValue(), 100.0f);
+}
+
+// Test scaling with factor == 1.0 (no scaling)
+TEST(FixedPointTest, ScaleFactorOne) {
+    ScaledValue<int16_t, 1, 1> value;
+    
+    value.setValue(42.0f);
+    EXPECT_EQ(value.getRaw(), 42);
+    EXPECT_FLOAT_EQ(value.getValue(), 42.0f);
+    
+    value = 100.5f;
+    EXPECT_EQ(value.getRaw(), 101);  // Rounded
+    EXPECT_FLOAT_EQ(value.getValue(), 101.0f);
+}
+
+// Test custom scale factor (multiply by 5)
+TEST(FixedPointTest, ScaleFactorFive) {
+    ScaledValue<int16_t, 5> value;
+    
+    value.setValue(50.0f);
+    EXPECT_EQ(value.getRaw(), 10);
+    EXPECT_FLOAT_EQ(value.getValue(), 50.0f);
+    
+    value.setValue(35.0f);
+    EXPECT_EQ(value.getRaw(), 7);
+    EXPECT_FLOAT_EQ(value.getValue(), 35.0f);
+}
+
+// Test rounding behavior
+TEST(FixedPointTest, Rounding) {
+    ScaledValue<int16_t, 1, 10> value;
+    
+    // Positive rounding
+    value.setValue(1.24f);
+    EXPECT_EQ(value.getRaw(), 12);  // Rounds down
+    
+    value.setValue(1.25f);
+    EXPECT_EQ(value.getRaw(), 13);  // Rounds up
+    
+    value.setValue(1.26f);
+    EXPECT_EQ(value.getRaw(), 13);  // Rounds up
+    
+    // Negative rounding
+    ScaledValue<int16_t, 1, 10> negValue;
+    negValue.setValue(-1.24f);
+    EXPECT_EQ(negValue.getRaw(), -12);  // Rounds toward zero
+    
+    negValue.setValue(-1.26f);
+    EXPECT_EQ(negValue.getRaw(), -13);  // Rounds away from zero
+}
+
+// Test clamping at maximum value
+TEST(FixedPointTest, ClampingMax) {
+    ScaledValue<int8_t, 1, 10> value;
+    
+    // int8_t max is 127, so max representable value is 127/10 = 12.7
+    value.setValue(20.0f);  // Too large
+    EXPECT_EQ(value.getRaw(), 127);
+    EXPECT_FLOAT_EQ(value.getValue(), 12.7f);
+}
+
+// Test clamping at minimum value
+TEST(FixedPointTest, ClampingMin) {
+    ScaledValue<int8_t, 1, 10> value;
+    
+    // int8_t min is -128, so min representable value is -128/10 = -12.8
+    value.setValue(-20.0f);  // Too small
+    EXPECT_EQ(value.getRaw(), -128);
+    EXPECT_FLOAT_EQ(value.getValue(), -12.8f);
+}
+
+// Test unsigned type clamping
+TEST(FixedPointTest, UnsignedClamping) {
+    ScaledValue<uint8_t, 1, 10> value;
+    
+    // uint8_t min is 0
+    value.setValue(-5.0f);  // Negative value
+    EXPECT_EQ(value.getRaw(), 0);
+    EXPECT_FLOAT_EQ(value.getValue(), 0.0f);
+    
+    // uint8_t max is 255
+    value.setValue(30.0f);  // Too large
+    EXPECT_EQ(value.getRaw(), 255);
+    EXPECT_FLOAT_EQ(value.getValue(), 25.5f);
+}
+
+// Test raw value access
+TEST(FixedPointTest, RawValueAccess) {
+    ScaledValue<int16_t, 1, 10> value;
+    
+    value.setRaw(100);
+    EXPECT_EQ(value.getRaw(), 100);
+    EXPECT_FLOAT_EQ(value.getValue(), 10.0f);
+}
+
+// Test implicit conversions
+TEST(FixedPointTest, ImplicitConversions) {
+    ScaledValue<int16_t, 1, 10> value;
+    
+    // Implicit assignment from float
+    value = 7.5f;
+    EXPECT_EQ(value.getRaw(), 75);
+    
+    // Implicit conversion to float
+    float result = value;
+    EXPECT_FLOAT_EQ(result, 7.5f);
+}
+
+// Test various data type combinations
+TEST(FixedPointTest, VariousDataTypes) {
+    // Small signed type
+    FixedPoint<int8_t, 2> int8Value;
+    int8Value = 10.0f;
+    EXPECT_EQ(int8Value.getRaw(), 20);
+    
+    // Small unsigned type
+    FixedPoint<uint8_t, 100> uint8Value;
+    uint8Value = 2.5f;
+    EXPECT_EQ(uint8Value.getRaw(), 250);
+}
+
+// Test fractional scale factors
+TEST(FixedPointTest, FractionalScaleFactors) {
+    ScaledValue<int16_t, 1, 2> halfScale;
+    halfScale = 100.0f;
+    EXPECT_EQ(halfScale.getRaw(), 200);
+    EXPECT_FLOAT_EQ(halfScale.getValue(), 100.0f);
+    
+    ScaledValue<int16_t, 1, 4> quarterScale;
+    quarterScale = 200.0f;
+    EXPECT_EQ(quarterScale.getRaw(), 800);
+    EXPECT_FLOAT_EQ(quarterScale.getValue(), 200.0f);
+    
+    ScaledValue<int16_t, 7, 2> mixedScale;
+    mixedScale = 35.0f;
+    EXPECT_EQ(mixedScale.getRaw(), 10);
+    EXPECT_NEAR(mixedScale.getValue(), 35.0f, 0.01f);
+}
+
+// Test edge cases with exact limits
+TEST(FixedPointTest, ExactLimits) {
+    ScaledValue<int16_t, 1, 1> value;
+    
+    // Test exact max
+    value.setValue(static_cast<float>(std::numeric_limits<int16_t>::max()));
+    EXPECT_EQ(value.getRaw(), std::numeric_limits<int16_t>::max());
+    
+    // Test exact min
+    value.setValue(static_cast<float>(std::numeric_limits<int16_t>::min()));
+    EXPECT_EQ(value.getRaw(), std::numeric_limits<int16_t>::min());
+}
+
+// Test that getValue/setValue are inverse operations
+TEST(FixedPointTest, InverseOperations) {
+    ScaledValue<int16_t, 1, 10> value;
+    
+    float testValues[] = {0.0f, 1.0f, 5.5f, -3.2f, 10.0f, -10.0f};
+    
+    for (float testValue : testValues) {
+        value.setValue(testValue);
+        float retrieved = value.getValue();
+        // Allow for rounding error (1 LSB in scaled representation)
+        EXPECT_NEAR(retrieved, testValue, 0.1f);
+    }
+}

--- a/test/tests/test_heater.cpp
+++ b/test/tests/test_heater.cpp
@@ -1,11 +1,22 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
+#include "fixed_point.h"
 #include "heater_control.h"
+
+struct MockConfiguration {
+    struct HeaterConfig heaterConfig {
+        .HeaterSupplyOffVoltage = { 60 }, // 6.0V
+        .HeaterSupplyOnVoltage = { 110 }, // 11.0V
+        .PreheatTimeSec = { 1 }, // 5 seconds
+        .pad = {0},
+    };
+} mockConfig;
 
 struct MockHeater : public HeaterControllerBase
 {
-    MockHeater() : HeaterControllerBase(0, 5, 10) { }
+    MockHeater() : HeaterControllerBase(0) {
+    }
 
     MOCK_METHOD(void, SetDuty, (float), (const, override));
 };
@@ -13,6 +24,7 @@ struct MockHeater : public HeaterControllerBase
 TEST(HeaterStateOutput, Preheat)
 {
     MockHeater dut;
+    dut.Configure(780, 300, &mockConfig.heaterConfig);
 
     // Shouldn't depend upon sensor ESR
     EXPECT_EQ(2.0f, dut.GetVoltageForState(HeaterState::Preheat, 0));
@@ -30,7 +42,7 @@ TEST(HeaterStateOutput, WarmupRamp)
 TEST(HeaterStateOutput, ClosedLoop)
 {
     MockHeater dut;
-    dut.Configure(780, 300);
+    dut.Configure(780, 300, &mockConfig.heaterConfig);
 
     // At target -> zero output but with 7.5v offset
     EXPECT_EQ(dut.GetVoltageForState(HeaterState::ClosedLoop, 300), 7.5f);
@@ -45,6 +57,7 @@ TEST(HeaterStateOutput, ClosedLoop)
 TEST(HeaterStateOutput, Cases)
 {
     MockHeater dut;
+    dut.Configure(780, 300, &mockConfig.heaterConfig);
 
     EXPECT_EQ(0, dut.GetVoltageForState(HeaterState::Stopped, 0));
     EXPECT_EQ(0, dut.GetVoltageForState(HeaterState::NoHeaterSupply, 0));
@@ -54,7 +67,7 @@ TEST(HeaterStateMachine, PreheatToWarmupTimeout)
 {
     MockHeater dut;
     Timer::setMockTime(0);
-    dut.Configure(780, 300);
+    dut.Configure(780, 300, &mockConfig.heaterConfig);
 
     // For a while it should stay in preheat
     Timer::setMockTime(1e6);
@@ -73,7 +86,7 @@ TEST(HeaterStateMachine, PreheatToWarmupAlreadyWarm)
 {
     MockHeater dut;
     Timer::setMockTime(0);
-    dut.Configure(780, 300);
+    dut.Configure(780, 300, &mockConfig.heaterConfig);
 
     // Preheat for a little while
     for (size_t i = 0; i < 10; i++)
@@ -89,7 +102,7 @@ TEST(HeaterStateMachine, WarmupToClosedLoop)
 {
     MockHeater dut;
     Timer::setMockTime(0);
-    dut.Configure(780, 300);
+    dut.Configure(780, 300, &mockConfig.heaterConfig);
 
     // Warm up for a little while
     for (size_t i = 0; i < 10; i++)
@@ -105,7 +118,7 @@ TEST(HeaterStateMachine, WarmupTimeout)
 {
     MockHeater dut;
     Timer::setMockTime(0);
-    dut.Configure(780, 300);
+    dut.Configure(780, 300, &mockConfig.heaterConfig);
 
     // For a while it should stay in warmup
     Timer::setMockTime(1e6);
@@ -116,7 +129,7 @@ TEST(HeaterStateMachine, WarmupTimeout)
     EXPECT_EQ(HeaterState::WarmupRamp, dut.GetNextState(HeaterState::WarmupRamp, HeaterAllow::Allowed, 12, 500));
 
     // Warmup times out, sensor transitions to stopped
-    Timer::setMockTime(10.1e6);
+    Timer::setMockTime(60.1e6);
     EXPECT_EQ(HeaterState::Stopped, dut.GetNextState(HeaterState::WarmupRamp, HeaterAllow::Allowed, 12, 500));
 }
 
@@ -124,7 +137,7 @@ TEST(HeaterStateMachine, ClosedLoop)
 {
     MockHeater dut;
     Timer::setMockTime(0);
-    dut.Configure(780, 300);
+    dut.Configure(780, 300, &mockConfig.heaterConfig);
 
     // Check 5 sec stabilization timeout
     EXPECT_EQ(HeaterState::ClosedLoop, dut.GetNextState(HeaterState::ClosedLoop, HeaterAllow::Allowed, 12, 780));
@@ -165,7 +178,7 @@ TEST(HeaterStateMachine, ClosedLoop)
 TEST(HeaterStateMachine, TerminalStates)
 {
     MockHeater dut;
-    dut.Configure(780, 300);
+    dut.Configure(780, 300, &mockConfig.heaterConfig);
 
     EXPECT_EQ(HeaterState::Stopped, dut.GetNextState(HeaterState::Stopped, HeaterAllow::Allowed, 12, 780));
 }


### PR DESCRIPTION
Moved some heater parameters into config memory.
Specifically
- `HeaterSupplyOffVoltage`
- `HeaterSupplyOnVoltage `
- `PreheatTimeSec`

This way the board could be configured to work independently of the ECU, so that
- Heater only turns on when alternator produces high enough voltage (as an indirect measurement of when engine is running), by setting `HeaterSupplyOnVoltage ` higher than ~13.5V
- And/or increasing `PreheatTimeSec` to 5-10 minutes to allow engine to warm up a bit, and water condensation to evaporate.

To conserve the precious RAM, `ScaledValue` struct is introduces, that allows seamlessly mapping int/uint values.
This way values could be mapped to integers, scaling them both up and down.
- Fractional point values, like `12.5` could be mapped to `125` in memory, if more precision is needed.
- Precision can be sacrificed to fit larger values into smaller types. E.g. values from 0 to 1275 can be fitted into uint8_t using steps of 5.

Added unit tests for `ScaledValue`, so that it definitely fits into its storage type
And unit tests for Configuration, to make sure changes to config structure would be backward-compatible with existing units.